### PR TITLE
Fix Postgres Integration && Add Redis Raw Command Length

### DIFF
--- a/lib/ddtrace/contrib/pg/patcher.rb
+++ b/lib/ddtrace/contrib/pg/patcher.rb
@@ -15,10 +15,6 @@ module Datadog
         end
 
         def patch
-          patch_pg_client
-        end
-
-        def patch_pg_client
           ::PG::Connection.send(:include, Connection)
         end
       end

--- a/lib/ddtrace/contrib/pg/patcher.rb
+++ b/lib/ddtrace/contrib/pg/patcher.rb
@@ -15,13 +15,7 @@ module Datadog
         end
 
         def patch
-          do_once(:pg) do
-            begin
-              patch_pg_client
-            rescue StandardError => e
-              Datadog::Tracer.log.error("Unable to apply pg integration: #{e}")
-            end
-          end
+          patch_pg_client
         end
 
         def patch_pg_client

--- a/lib/ddtrace/contrib/redis/ext.rb
+++ b/lib/ddtrace/contrib/redis/ext.rb
@@ -15,7 +15,7 @@ module Datadog
         SPAN_COMMAND = 'redis.command'.freeze
         TAG_DB = 'out.redis_db'.freeze
         TAG_RAW_COMMAND = 'redis.raw_command'.freeze
-        METRIC_RAW_COMMAND_LENGTH = 'redis.raw_command_length'.freeze
+        METRIC_RAW_COMMAND_LEN = 'redis.raw_command_length'.freeze
         TYPE = 'redis'.freeze
       end
     end

--- a/lib/ddtrace/contrib/redis/ext.rb
+++ b/lib/ddtrace/contrib/redis/ext.rb
@@ -15,6 +15,7 @@ module Datadog
         SPAN_COMMAND = 'redis.command'.freeze
         TAG_DB = 'out.redis_db'.freeze
         TAG_RAW_COMMAND = 'redis.raw_command'.freeze
+        METRIC_RAW_COMMAND_LENGTH = 'redis.raw_command_length'.freeze
         TYPE = 'redis'.freeze
       end
     end

--- a/lib/ddtrace/contrib/redis/patcher.rb
+++ b/lib/ddtrace/contrib/redis/patcher.rb
@@ -42,6 +42,7 @@ module Datadog
                 span.service = pin.service
                 span.span_type = Datadog::Contrib::Redis::Ext::TYPE
                 span.resource = get_command(args)
+                span.set_metric Datadog::Contrib::Redis::Ext::METRIC_RAW_COMMAND_LENGTH, args.to_s.length
                 Datadog::Contrib::Redis::Tags.set_common_tags(self, span)
 
                 response = call_without_datadog(*args, &block)
@@ -63,6 +64,7 @@ module Datadog
                 commands = get_pipeline_commands(args)
                 span.resource = commands.join("\n")
                 span.set_metric Datadog::Contrib::Redis::Ext::METRIC_PIPELINE_LEN, commands.length
+                span.set_metric Datadog::Contrib::Redis::Ext::METRIC_RAW_COMMAND_LENGTH, args.to_s.length
                 Datadog::Contrib::Redis::Tags.set_common_tags(self, span)
 
                 response = call_pipeline_without_datadog(*args, &block)

--- a/lib/ddtrace/contrib/redis/patcher.rb
+++ b/lib/ddtrace/contrib/redis/patcher.rb
@@ -42,7 +42,7 @@ module Datadog
                 span.service = pin.service
                 span.span_type = Datadog::Contrib::Redis::Ext::TYPE
                 span.resource = get_command(args)
-                span.set_metric Datadog::Contrib::Redis::Ext::METRIC_RAW_COMMAND_LENGTH, args.to_s.length
+                span.set_metric Datadog::Contrib::Redis::Ext::METRIC_RAW_COMMAND_LEN, args.to_s.length
                 Datadog::Contrib::Redis::Tags.set_common_tags(self, span)
 
                 response = call_without_datadog(*args, &block)
@@ -64,7 +64,7 @@ module Datadog
                 commands = get_pipeline_commands(args)
                 span.resource = commands.join("\n")
                 span.set_metric Datadog::Contrib::Redis::Ext::METRIC_PIPELINE_LEN, commands.length
-                span.set_metric Datadog::Contrib::Redis::Ext::METRIC_RAW_COMMAND_LENGTH, args.to_s.length
+                span.set_metric Datadog::Contrib::Redis::Ext::METRIC_RAW_COMMAND_LEN, args.to_s.length
                 Datadog::Contrib::Redis::Tags.set_common_tags(self, span)
 
                 response = call_pipeline_without_datadog(*args, &block)


### PR DESCRIPTION
`do_once` was removed, so this fixes the postgres integration.

Also this adds a metric to redis spans for the raw command length. It's pretty rudimentary and includes some extra array notation, but this seems to be a cheap way to approximate it. From a byebug inside of the patched method:

```
(byebug) args
[[:hscan, "mongos:substring:filter", 0, "COUNT", 1000]]

(byebug) args.to_s
"[[:hscan, \"mongos:substring:filter\", 0, \"COUNT\", 1000]]"

(byebug) args.to_s.length
55
```