### PR TITLE
[MOPS-596] Fix namespacing of endpoints in the rest-app that broke with the upgrade

### DIFF
--- a/lib/ddtrace/contrib/grape/endpoint.rb
+++ b/lib/ddtrace/contrib/grape/endpoint.rb
@@ -40,7 +40,15 @@ module Datadog
 
             # collect endpoint details
             endpoint = payload.fetch(:endpoint)
-            api_view = api_view(endpoint.options[:for])
+
+            # BRAZE MODIFICATION
+            # The changes here https://github.com/ruby-grape/grape/issues/1825 don't work with the way we use grape
+            api = endpoint.options[:for]
+            api_view = api.to_s
+            if api_view.blank?
+              api_view = api_view(api)
+            end
+
             request_method = endpoint.options.fetch(:method).first
             path = endpoint_expand_path(endpoint)
             resource = "#{api_view} #{request_method} #{path}"


### PR DESCRIPTION
dcd0bd08c72bc6588df17158004a6c1ca53d7919 added coercion of the endpoint namespace when the endpoint was run, this adds coercion when the endpoint starts processing so it gets added to the span appropriately. I was seeing the following 


> (byebug) endpoint.to_s
"#<#<Class:0x00007fece77fac20>:0x00007fece6ab4e80>"
(byebug) endpoint.options[:for]
Appboy::External::API::Campaigns::Service
(byebug) api.to_s
"Appboy::External::API::Campaigns::Service"
(byebug) api = endpoint.options[:for]
Appboy::External::API::Campaigns::Service
(byebug) api_view = api.to_s
"Appboy::External::API::Campaigns::Service"
(byebug) api_view.blank?
false
(byebug) span.resource
" POST //trigger/send"
(byebug) tracer.active_span

so the span wasn't getting the right endpoint. 

I wish I had a better fix for this or a more concrete explanation of why this was happening. I tried fixing this platform side in the grape adapter / service base and got a ton of failures. I think it has to do with how we mount our external api because this isn't a problem in the transactional api, which is more recent. https://github.com/ruby-grape/grape/issues/1825 seems to be when it started breaking for us. 

I wrote a corresponding test in platform that I will green when this is merged. My understanding is that I will need to:
* merge this to deployed-in-platform
* create a new tag for this change
* update the base image and update the image reference in platform, as well as the gemfile

Let me know if I'm missing anything - the hope is that after i merge this plati will have ownership of this change as owners of the fork (thank you!)

