### PR TITLE
Attempt to add response size to redis traces

### DIFF
--- a/lib/datadog/tracing/contrib/redis/ext.rb
+++ b/lib/datadog/tracing/contrib/redis/ext.rb
@@ -17,6 +17,7 @@ module Datadog
           TAG_RAW_COMMAND = 'redis.raw_command'.freeze
           ### BRAZE MODIFICATION
           METRIC_RAW_COMMAND_LEN = 'redis.raw_command_length'.freeze
+          METRIC_RESP_COMMAND_LEN = 'redis.raw_response_length'.freeze
           ### END BRAZE MODIFICATION
           TYPE = 'redis'.freeze
           TAG_COMPONENT = 'redis'.freeze

--- a/lib/datadog/tracing/contrib/redis/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/redis/instrumentation.rb
@@ -28,7 +28,13 @@ module Datadog
                 ### END BRAZE MODIFICATION
                 Contrib::Redis::Tags.set_common_tags(self, span, show_command_args)
 
-                super
+                result = super
+
+                ### BRAZE MODIFICATION
+                span.set_metric Contrib::Redis::Ext::METRIC_RESP_COMMAND_LEN, result.to_s.bytesize
+                ### END BRAZE MODIFICATION
+
+                result
               end
             end
 
@@ -46,7 +52,13 @@ module Datadog
                 ### END BRAZE MODIFICATION
                 Contrib::Redis::Tags.set_common_tags(self, span, show_command_args)
 
-                super
+                result = super
+
+                ### BRAZE MODIFICATION
+                span.set_metric Contrib::Redis::Ext::METRIC_RESP_COMMAND_LEN, result.to_s.bytesize
+                ### END BRAZE MODIFICATION
+
+                result
               end
             end
 


### PR DESCRIPTION
This should give us a metric on redis traces with a roughly-correct response size.

(roughly correct because this is not getting redis-protocol level responses, but the data coming out of the method call which is often an array, etc.)