### PR TITLE
[PLATI-981] Add codeowner to Redis traces

### DIFF
--- a/lib/datadog/tracing/contrib/redis/ext.rb
+++ b/lib/datadog/tracing/contrib/redis/ext.rb
@@ -18,6 +18,8 @@ module Datadog
           ### BRAZE MODIFICATION
           METRIC_RAW_COMMAND_LEN = 'redis.raw_command_length'.freeze
           METRIC_RESP_COMMAND_LEN = 'redis.raw_response_length'.freeze
+          METRIC_FILEPATH = 'filepath'.freeze
+          METRIC_CODEOWNER = 'codeowner'.freeze
           ### END BRAZE MODIFICATION
           TYPE = 'redis'.freeze
           TAG_COMPONENT = 'redis'.freeze

--- a/lib/datadog/tracing/contrib/redis/ext.rb
+++ b/lib/datadog/tracing/contrib/redis/ext.rb
@@ -18,8 +18,8 @@ module Datadog
           ### BRAZE MODIFICATION
           METRIC_RAW_COMMAND_LEN = 'redis.raw_command_length'.freeze
           METRIC_RESP_COMMAND_LEN = 'redis.raw_response_length'.freeze
-          METRIC_FILEPATH = 'filepath'.freeze
-          METRIC_CODEOWNER = 'codeowner'.freeze
+          METRIC_FILEPATH = 'redis.filepath'.freeze
+          METRIC_CODEOWNER = 'redis.codeowner'.freeze
           THREAD_GLOBAL_FILEPATH = :redis_operation_filepath
           THREAD_GLOBAL_CODEOWNER = :redis_operation_codeowner
           ### END BRAZE MODIFICATION

--- a/lib/datadog/tracing/contrib/redis/ext.rb
+++ b/lib/datadog/tracing/contrib/redis/ext.rb
@@ -20,6 +20,8 @@ module Datadog
           METRIC_RESP_COMMAND_LEN = 'redis.raw_response_length'.freeze
           METRIC_FILEPATH = 'filepath'.freeze
           METRIC_CODEOWNER = 'codeowner'.freeze
+          THREAD_GLOBAL_FILEPATH = :redis_operation_filepath
+          THREAD_GLOBAL_CODEOWNER = :redis_operation_codeowner
           ### END BRAZE MODIFICATION
           TYPE = 'redis'.freeze
           TAG_COMPONENT = 'redis'.freeze

--- a/lib/datadog/tracing/contrib/redis/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/redis/instrumentation.rb
@@ -28,7 +28,7 @@ module Datadog
 
                 if Thread.current[:redis_operation_filepath].present?
                   span.set_tag(
-                    Contrib::Redis::Ext::METRIC_FILEPATH
+                    Contrib::Redis::Ext::METRIC_FILEPATH,
                     Thread.current[:redis_operation_filepath]
                   )
                 end
@@ -66,7 +66,7 @@ module Datadog
 
                 if Thread.current[:redis_operation_filepath].present?
                   span.set_tag(
-                    Contrib::Redis::Ext::METRIC_FILEPATH
+                    Contrib::Redis::Ext::METRIC_FILEPATH,
                     Thread.current[:redis_operation_filepath]
                   )
                 end

--- a/lib/datadog/tracing/contrib/redis/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/redis/instrumentation.rb
@@ -25,6 +25,20 @@ module Datadog
                 span.resource = get_command(args, show_command_args)
                 ### BRAZE MODIFICATION
                 span.set_metric Contrib::Redis::Ext::METRIC_RAW_COMMAND_LEN, args.to_s.length
+
+                if Thread.current[:redis_operation_filepath].present?
+                  span.set_tag(
+                    Contrib::Redis::Ext::METRIC_FILEPATH
+                    Thread.current[:redis_operation_filepath]
+                  )
+                end
+
+                if Thread.current[:redis_operation_codeowner].present?
+                  span.set_tag(
+                    Contrib::Redis::Ext::METRIC_CODEOWNER,
+                    Thread.current[:redis_operation_codeowner]
+                  )
+                end
                 ### END BRAZE MODIFICATION
                 Contrib::Redis::Tags.set_common_tags(self, span, show_command_args)
 
@@ -49,6 +63,20 @@ module Datadog
                 span.set_metric Contrib::Redis::Ext::METRIC_PIPELINE_LEN, commands.length
                 ### BRAZE MODIFICATION
                 span.set_metric Contrib::Redis::Ext::METRIC_RAW_COMMAND_LEN, args.to_s.length
+
+                if Thread.current[:redis_operation_filepath].present?
+                  span.set_tag(
+                    Contrib::Redis::Ext::METRIC_FILEPATH
+                    Thread.current[:redis_operation_filepath]
+                  )
+                end
+
+                if Thread.current[:redis_operation_codeowner].present?
+                  span.set_tag(
+                    Contrib::Redis::Ext::METRIC_CODEOWNER,
+                    Thread.current[:redis_operation_codeowner]
+                  )
+                end
                 ### END BRAZE MODIFICATION
                 Contrib::Redis::Tags.set_common_tags(self, span, show_command_args)
 

--- a/lib/datadog/tracing/contrib/redis/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/redis/instrumentation.rb
@@ -26,17 +26,17 @@ module Datadog
                 ### BRAZE MODIFICATION
                 span.set_metric Contrib::Redis::Ext::METRIC_RAW_COMMAND_LEN, args.to_s.length
 
-                if Thread.current[:redis_operation_filepath].present?
+                if Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_FILEPATH].present?
                   span.set_tag(
                     Contrib::Redis::Ext::METRIC_FILEPATH,
-                    Thread.current[:redis_operation_filepath]
+                    Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_FILEPATH]
                   )
                 end
 
-                if Thread.current[:redis_operation_codeowner].present?
+                if Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_CODEOWNER].present?
                   span.set_tag(
                     Contrib::Redis::Ext::METRIC_CODEOWNER,
-                    Thread.current[:redis_operation_codeowner]
+                    Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_CODEOWNER]
                   )
                 end
                 ### END BRAZE MODIFICATION
@@ -64,17 +64,17 @@ module Datadog
                 ### BRAZE MODIFICATION
                 span.set_metric Contrib::Redis::Ext::METRIC_RAW_COMMAND_LEN, args.to_s.length
 
-                if Thread.current[:redis_operation_filepath].present?
+                if Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_FILEPATH].present?
                   span.set_tag(
                     Contrib::Redis::Ext::METRIC_FILEPATH,
-                    Thread.current[:redis_operation_filepath]
+                    Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_FILEPATH]
                   )
                 end
 
-                if Thread.current[:redis_operation_codeowner].present?
+                if Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_CODEOWNER].present?
                   span.set_tag(
                     Contrib::Redis::Ext::METRIC_CODEOWNER,
-                    Thread.current[:redis_operation_codeowner]
+                    Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_CODEOWNER]
                   )
                 end
                 ### END BRAZE MODIFICATION

--- a/lib/datadog/tracing/contrib/redis/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/redis/instrumentation.rb
@@ -33,7 +33,7 @@ module Datadog
                   )
                 end
 
-                if Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_CODEOWNER].present?
+                if !Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_CODEOWNER].nil?
                   span.set_tag(
                     Contrib::Redis::Ext::METRIC_CODEOWNER,
                     Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_CODEOWNER]
@@ -64,14 +64,14 @@ module Datadog
                 ### BRAZE MODIFICATION
                 span.set_metric Contrib::Redis::Ext::METRIC_RAW_COMMAND_LEN, args.to_s.length
 
-                if Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_FILEPATH].present?
+                if !Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_FILEPATH].nil?
                   span.set_tag(
                     Contrib::Redis::Ext::METRIC_FILEPATH,
                     Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_FILEPATH]
                   )
                 end
 
-                if Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_CODEOWNER].present?
+                if !Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_CODEOWNER].nil?
                   span.set_tag(
                     Contrib::Redis::Ext::METRIC_CODEOWNER,
                     Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_CODEOWNER]

--- a/lib/datadog/tracing/contrib/redis/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/redis/instrumentation.rb
@@ -26,7 +26,7 @@ module Datadog
                 ### BRAZE MODIFICATION
                 span.set_metric Contrib::Redis::Ext::METRIC_RAW_COMMAND_LEN, args.to_s.length
 
-                if Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_FILEPATH].present?
+                if !Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_FILEPATH].nil?
                   span.set_tag(
                     Contrib::Redis::Ext::METRIC_FILEPATH,
                     Thread.current[Contrib::Redis::Ext::THREAD_GLOBAL_FILEPATH]


### PR DESCRIPTION
Changes to the `dd-trace-rb` Redis integration to capture codeowner and filepath information for redis calls, when they are set in thread globals.

Required for https://github.com/Appboy/platform/pull/66471