### PR TITLE
Dalli: don't encode the command

### DIFF
--- a/lib/datadog/tracing/contrib/dalli/quantize.rb
+++ b/lib/datadog/tracing/contrib/dalli/quantize.rb
@@ -9,9 +9,7 @@ module Datadog
           module_function
 
           def format_command(operation, args)
-            placeholder = "#{operation} BLOB (OMITTED)"
-            command = [operation, *args].join(' ').strip
-            command = Core::Utils.utf8_encode(command, binary: true, placeholder: placeholder)
+            command = "#{operation} #{args[0]}"
             Core::Utils.truncate(command, Ext::QUANTIZE_MAX_CMD_LENGTH)
           rescue => e
             Datadog.logger.debug("Error sanitizing Dalli operation: #{e}")


### PR DESCRIPTION
This just wastes CPU cycles. It was encoding the _entire_ command (including the payload, for a SET), and wasn't even doing the truncation first.

Just take the operation and the first arg (typically the key), and skip the encoding altogether. There's probably a better way to do even this than string interpolation 

I'm tempted to just rip out the dalli integration entirely and add spans in `Appboy::Cache`. I don't really trust dd-trace in hot path code.
