### PR TITLE
Fix patching of ActiveSupport::Cache

### DIFF
--- a/lib/datadog/tracing/contrib/active_support/cache/redis.rb
+++ b/lib/datadog/tracing/contrib/active_support/cache/redis.rb
@@ -23,6 +23,10 @@ module Datadog
               # ActiveSupport includes a Redis cache store internally, and does not require these overrides.
               # https://github.com/rails/rails/blob/master/activesupport/lib/active_support/cache/redis_cache_store.rb
               def patch_redis?(meth)
+                ### BRAZE MODIFICATION
+                # we do not use redis with `ActiveSupport::Cache`, and this causes the wrong `Store` to be patched
+                return false
+                ### END BRAZE MODIFICATION
                 !Gem.loaded_specs['redis-activesupport'].nil? \
                   && defined?(::ActiveSupport::Cache::RedisStore) \
                   && ::ActiveSupport::Cache::RedisStore.instance_methods(false).include?(meth)


### PR DESCRIPTION
For each method (:read, :write, etc), the patcher chooses only one class to patch. In the case of `:write`, it patches `RedisStore`, since that class redefines `Store#write`

A better solution would be to patch multiple classes for each method, depending on where that method is defined. But since we don't use redis with `ActiveSupport::Cache` at all, this is an easier solution.

This could potentially also be done in a platform initializer, but since the patcher runs before the initializer would, that seemed like it would be trickier to accomplish.

