### PR TITLE
Improve key quantization and add command length

### DIFF
--- a/lib/datadog/tracing/contrib/dalli/ext.rb
+++ b/lib/datadog/tracing/contrib/dalli/ext.rb
@@ -26,6 +26,9 @@ module Datadog
           SPAN_COMMAND = 'memcached.command'
           SPAN_TYPE_COMMAND = 'memcached'
           TAG_COMMAND = 'memcached.command'
+          # BEGIN BRAZE MODIFICATION
+          TAG_LENGTH = 'memcached.length'
+          # END BRAZE MODIFICATION
           TAG_COMPONENT = 'dalli'
           TAG_OPERATION_COMMAND = 'command'
           TAG_SYSTEM = 'memcached'

--- a/lib/datadog/tracing/contrib/dalli/ext.rb
+++ b/lib/datadog/tracing/contrib/dalli/ext.rb
@@ -27,6 +27,7 @@ module Datadog
           SPAN_TYPE_COMMAND = 'memcached'
           TAG_COMMAND = 'memcached.command'
           # BEGIN BRAZE MODIFICATION
+          TAG_QUANTIZED_COMMAND = 'memcached.quantized_command'
           TAG_LENGTH = 'memcached.length'
           # END BRAZE MODIFICATION
           TAG_COMPONENT = 'dalli'

--- a/lib/datadog/tracing/contrib/dalli/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/dalli/instrumentation.rb
@@ -53,12 +53,13 @@ module Datadog
                 span.set_tag(Contrib::Ext::DB::TAG_SYSTEM, Ext::TAG_SYSTEM)
 
                 if datadog_configuration[:command_enabled]
-                  cmd = Quantize.format_command(op, args)
+                  # BEGIN BRAZE MODIFICATION
+                  cmd, q_cmd, length = Quantize.format_command(op, args)
                   span.set_tag(Ext::TAG_COMMAND, cmd)
+                  span.set_tag(Ext::TAG_QUANTIZED_COMMAND, q_cmd)
+                  span.set_tag(Ext::TAG_LENGTH, length)
+                  # END BRAZE MODIFICATION
                 end
-                # BEGIN BRAZE MODIFICATION
-                span.set_tag(Ext::TAG_LENGTH, Core::Utils.utf8_encode([op, *args].join(' ').strip, binary: true).length)
-                # END BRAZE MODIFICATION
 
                 Contrib::SpanAttributeSchema.set_peer_service!(span, Ext::PEER_SERVICE_SOURCES)
                 super

--- a/lib/datadog/tracing/contrib/dalli/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/dalli/instrumentation.rb
@@ -56,6 +56,9 @@ module Datadog
                   cmd = Quantize.format_command(op, args)
                   span.set_tag(Ext::TAG_COMMAND, cmd)
                 end
+                # BEGIN BRAZE MODIFICATION
+                span.set_tag(Ext::TAG_LENGTH, Core::Utils.utf8_encode([op, *args].join(' ').strip, binary: true).length)
+                # END BRAZE MODIFICATION
 
                 Contrib::SpanAttributeSchema.set_peer_service!(span, Ext::PEER_SERVICE_SOURCES)
                 super

--- a/lib/datadog/tracing/contrib/dalli/quantize.rb
+++ b/lib/datadog/tracing/contrib/dalli/quantize.rb
@@ -8,12 +8,32 @@ module Datadog
       module Dalli
         # Quantize contains dalli-specic quantization tools.
         module Quantize
+          # BEGIN BRAZE MODIFICATION
+          GUID_ID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
+          BSON_ID_REGEX = /[0-9a-f]{24}/i
+          XXHASH_REGEX = /[0-9a-f]{16}/
+          INTEGER_ID_REGEX = /\d+/
+          # END BRAZE MODIFICATION
           module_function
 
           def format_command(operation, args)
             placeholder = "#{operation} BLOB (OMITTED)"
-            command = [operation, *args].join(' ').strip
+            # BEGIN BRAZE MODIFICATION
+            if operation == :send_multiget
+              command = [operation, *args].join(' ').strip
+            else
+              # all operations except multiget have the key as the first arg
+              command = [operation, args[0]].join(' ').strip
+            end
+            # END BRAZE MODIFICATION
+
             command = Core::Utils.utf8_encode(command, binary: true, placeholder: placeholder)
+            # BEGIN BRAZE MODIFICATION
+            command = command.gsub(GUID_ID_REGEX, "GUID")
+            command = command.gsub(BSON_ID_REGEX, "BSON")
+            command = command.gsub(XXHASH_REGEX, "XXHASH")
+            command = command.gsub(INTEGER_ID_REGEX, "INTEGER")
+            # END BRAZE MODIFICATION
             Core::Utils.truncate(command, Ext::QUANTIZE_MAX_CMD_LENGTH)
           rescue => e
             Datadog.logger.debug("Error sanitizing Dalli operation: #{e}")

--- a/lib/datadog/tracing/contrib/dalli/quantize.rb
+++ b/lib/datadog/tracing/contrib/dalli/quantize.rb
@@ -12,11 +12,11 @@ module Datadog
           GUID_ID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
           BSON_ID_REGEX = /[0-9a-f]{24}/i
           XXHASH_REGEX = /[0-9a-f]{16}/
-          INTEGER_ID_REGEX = /\d+/
+          INTEGER_ID_REGEX = /\d\d+/ # 2 or more digits (to exclude things like ":v2")
           # END BRAZE MODIFICATION
           module_function
 
-          def format_command(operation, args)
+          def format_command(operation, args, truncate = true)
             placeholder = "#{operation} BLOB (OMITTED)"
             # BEGIN BRAZE MODIFICATION
             if operation == :send_multiget
@@ -29,12 +29,17 @@ module Datadog
 
             command = Core::Utils.utf8_encode(command, binary: true, placeholder: placeholder)
             # BEGIN BRAZE MODIFICATION
-            command = command.gsub(GUID_ID_REGEX, "GUID")
-            command = command.gsub(BSON_ID_REGEX, "BSON")
-            command = command.gsub(XXHASH_REGEX, "XXHASH")
-            command = command.gsub(INTEGER_ID_REGEX, "INTEGER")
+            quantized_command = command.gsub(GUID_ID_REGEX, "GUID")
+            quantized_command = quantized_command.gsub(BSON_ID_REGEX, "BSON")
+            quantized_command = quantized_command.gsub(XXHASH_REGEX, "XXHASH")
+            quantized_command = quantized_command.gsub(INTEGER_ID_REGEX, "INTEGER")
+
+            [
+              Core::Utils.truncate(command, Ext::QUANTIZE_MAX_CMD_LENGTH),
+              Core::Utils.truncate(quantized_command, Ext::QUANTIZE_MAX_CMD_LENGTH),
+              command.length,
+            ]
             # END BRAZE MODIFICATION
-            Core::Utils.truncate(command, Ext::QUANTIZE_MAX_CMD_LENGTH)
           rescue => e
             Datadog.logger.debug("Error sanitizing Dalli operation: #{e}")
             placeholder

--- a/lib/datadog/tracing/contrib/dalli/quantize.rb
+++ b/lib/datadog/tracing/contrib/dalli/quantize.rb
@@ -9,14 +9,13 @@ module Datadog
         # Quantize contains dalli-specic quantization tools.
         module Quantize
           # BEGIN BRAZE MODIFICATION
-          GUID_ID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
-          BSON_ID_REGEX = /[0-9a-f]{24}/i
-          XXHASH_REGEX = /[0-9a-f]{16}/
-          INTEGER_ID_REGEX = /\d\d+/ # 2 or more digits (to exclude things like ":v2")
+          # Combined regex for quantizing IDs - order matters (most specific first)
+          # GUID > BSON (24 hex) > XXHASH (16 hex) > INTEGER (2+ digits)
+          QUANTIZE_ID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]{24}|[0-9a-f]{16}|\d{2,}/
           # END BRAZE MODIFICATION
           module_function
 
-          def format_command(operation, args, truncate = true)
+          def format_command(operation, args)
             placeholder = "#{operation} BLOB (OMITTED)"
             # BEGIN BRAZE MODIFICATION
             if operation == :send_multiget
@@ -29,11 +28,7 @@ module Datadog
 
             command = Core::Utils.utf8_encode(command, binary: true, placeholder: placeholder)
             # BEGIN BRAZE MODIFICATION
-            quantized_command = command.gsub(GUID_ID_REGEX, "GUID")
-            quantized_command = quantized_command.gsub(BSON_ID_REGEX, "BSON")
-            quantized_command = quantized_command.gsub(XXHASH_REGEX, "XXHASH")
-            quantized_command = quantized_command.gsub(INTEGER_ID_REGEX, "INTEGER")
-
+            quantized_command = command.gsub(QUANTIZE_ID_REGEX, "#")
             [
               Core::Utils.truncate(command, Ext::QUANTIZE_MAX_CMD_LENGTH),
               Core::Utils.truncate(quantized_command, Ext::QUANTIZE_MAX_CMD_LENGTH),


### PR DESCRIPTION
This should allow us to quantize the keys better.

Also provides a new LENGTH tag on the spans to help identify large cached items better