### PR TITLE
[PLATI-1319] Add redis.key to Redis spans

### DIFF
--- a/lib/datadog/tracing/contrib/redis/ext.rb
+++ b/lib/datadog/tracing/contrib/redis/ext.rb
@@ -25,6 +25,7 @@ module Datadog
           METRIC_FILEPATH = 'redis.filepath'.freeze
           METRIC_CODEOWNER = 'redis.codeowner'.freeze
           METRIC_SHARD_INDEX = 'redis.shard_index'.freeze
+          METRIC_KEY = 'redis.key'.freeze
           THREAD_GLOBAL_FILEPATH = :redis_operation_filepath
           THREAD_GLOBAL_CODEOWNER = :redis_operation_codeowner
           THREAD_GLOBAL_SHARD_INDEX = :redis_operation_shard_index

--- a/lib/datadog/tracing/contrib/redis/trace_middleware.rb
+++ b/lib/datadog/tracing/contrib/redis/trace_middleware.rb
@@ -30,6 +30,12 @@ module Datadog
                 Contrib::Redis::Tags.set_common_tags(client, span, raw_command)
 
                 ### BRAZE MODIFICATION
+                if command.is_a?(Array) && command.size > 1
+                  span.set_tag(
+                    Contrib::Redis::Ext::METRIC_KEY,
+                    command[1]
+                  )
+                end
                 span.set_metric Contrib::Redis::Ext::METRIC_RAW_COMMAND_LEN, raw_command.to_s.length
                 result = yield
                 span.set_metric Contrib::Redis::Ext::METRIC_RESP_COMMAND_LEN, result.to_s.bytesize


### PR DESCRIPTION
Extract the key from Redis commands and set it as a tag on the span

Tested locally:
![image](https://github.com/user-attachments/assets/0e6f84da-eed3-41c6-8ff2-891b79f619e4)
