### PR TITLE
Attempt to fix DD malformed version

### DIFF
--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -455,10 +455,14 @@ module Datadog
                         # Use provided tags or default tags if none.
                         tags || @tags.dup
                       end
+        ### BRAZE MODIFICATION
+        # We need to keep the version tag
+        #
         # Remove version tag if service is not the default service
-        if merged_tags.key?(Core::Environment::Ext::TAG_VERSION) && service && service != @default_service
-          merged_tags.delete(Core::Environment::Ext::TAG_VERSION)
-        end
+        # if merged_tags.key?(Core::Environment::Ext::TAG_VERSION) && service && service != @default_service
+        #   merged_tags.delete(Core::Environment::Ext::TAG_VERSION)
+        # end
+        ### END BRAZE MODIFICATION
         merged_tags
       end
 


### PR DESCRIPTION
We saw a small percentage of [requests](https://app.datadoghq.com/apm/traces?query=%40version%3A%2Arelease%2A&agg_m=count&agg_m_source=base&agg_q=env&agg_q_source=base&agg_t=count&analyticsOptions=%5B%22line%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code%2C%40host%2Ckube_container_name%2C%40version%2C%40git.commit.sha&fromUser=false&graphType=span_list&historicalData=true&messageDisplay=inline&shouldShowLegend=true&sort=desc&spanType=all&spanViewType=infrastructure&step=auto&storage=hot&top_n=10&top_o=top&view=spans&viz=stream&x_missing=true&start=1748879967932&end=1748966367932&paused=false) with malformed version tag. This is likely caused by ddtrace removing the version tag for spans that are not using the default service name - https://github.com/DataDog/dd-trace-rb/pull/4027. This change restores the previous behavior.