### PR TITLE
Update CODEOWNERS to SRE

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Appboy/sidekiq-and-monolith-foundations
+* @Appboy/data-orchestration-sre


### PR DESCRIPTION
per https://docs.google.com/spreadsheets/d/11y3xltpOAqnxkhkOzxvMClK5njo4VDB9kpSeuvtz9_4/edit?gid=0#gid=0, "SRE" has been marked as the new owner of this gem used in `platform`

(I assume Data & Orchestration SRE, and not the DevOps SRE team https://github.com/orgs/Appboy/teams/sre)